### PR TITLE
Use the ClassLoader class of composer extension repository

### DIFF
--- a/NamespaceClassLoader.php
+++ b/NamespaceClassLoader.php
@@ -35,7 +35,13 @@ class NamespaceClassLoader
     public static function loadClassLoader($class)
     {
         if ('Composer\Autoload\ClassLoader' === $class) {
-            require TL_ROOT . '/system/modules/_autoload/library/Composer/Autoload/ClassLoader.php';
+	        if(file_exists(TL_ROOT . '/composer/vendor/composer/ClassLoader.php'))
+            {
+                require_once(TL_ROOT . '/composer/vendor/composer/ClassLoader.php');
+            }
+            else {
+                require_once(TL_ROOT . '/system/modules/_autoload/library/Composer/Autoload/ClassLoader.php');
+            }
         }
     }
 


### PR DESCRIPTION
The used ClassLoader in library is outdated (API changes). It will cause an error when using the NamespaceClassLoader in an Contao setup where the Composer extension repository is used because the ClassLoader of this extension is used for the whole system.

Updating the ClassLoader would solve this issue. I think it is better to use the ClassLoader of the main composer installation if available
